### PR TITLE
User might manually cancel the restart operation

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/freeplugins/PluginImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/freeplugins/PluginImpl.java
@@ -34,9 +34,12 @@ import hudson.model.Hudson;
 import hudson.model.UpdateCenter;
 import hudson.model.UpdateSite;
 import hudson.security.ACL;
+import hudson.triggers.SafeTimerTask;
+import hudson.triggers.Trigger;
 import hudson.util.PersistedList;
 import hudson.util.TimeUnit2;
 import hudson.util.VersionNumber;
+import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.jvnet.hudson.reactor.Milestone;
@@ -351,6 +354,14 @@ public class PluginImpl extends Plugin {
                             // ignore
                         }
                         Hudson.getInstance().safeRestart();
+                        // if the user manually cancelled the quiet down, reflect that in the status message
+                        Trigger.timer.scheduleAtFixedRate(new SafeTimerTask() {
+                            @Override
+                            protected void doRun() throws Exception {
+                                if (!Jenkins.getInstance().isQuietingDown())
+                                    status = null;
+                            }
+                        },1000,1000);
                     } catch (RestartNotSupportedException exception) {
                         // ignore if restart is not allowed
                         status = Messages._Notice_restartRequired();


### PR DESCRIPTION
This is based on the following conversation:

```
(10:54:18 AM) rpetti: ugh, really? I need to restart my instance in order to install the free cloudbees plugins? :(
(10:54:52 AM) rpetti: is there a way to cancel that?
(10:56:09 AM) rpetti: kohsuke: is there any way to cancel the cloudbees plugin gateway's scheduled safe restart?
(10:56:32 AM) rpetti: I installed it thinking I didn't have to do that, since most plugins work without restarting. :/
(10:56:48 AM) kohsuke: hmm, that's true
(10:57:17 AM) kohsuke: stephenc would know if that autorestart can be cancelled but let me check the code
(10:58:18 AM) rpetti: I can cancel the "jenkins is going to shut down" thing, but the banner still says a restart has been scheduled
(11:05:27 AM) kohsuke: rpetti: I read the code, and your cancelling the "Jenkins is going to shutdown" is sufficient
(11:05:51 AM) rpetti: ok, thanks!
(11:05:52 AM) kohsuke: but the code on our side isn't smart enough to notice that the restart was cancelled, so the notice won't go away
(11:06:14 AM) rpetti: kk
(11:06:49 AM) kohsuke: rpetti:  I suspect if you do com.cloudbees.jenkins.plugins.freeplugins.PluginImpl.@status= null from groovy console it'd shut up
(11:08:01 AM) rpetti: kohsuke: huzzah! that worked perfectly :)
(11:08:17 AM) rpetti: kohsuke: thanks again
```
