### PR TITLE
Fix invalid SSL hostname certificate issue.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/freeplugins/PluginImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/freeplugins/PluginImpl.java
@@ -80,7 +80,7 @@ public class PluginImpl extends Plugin {
      */
     private static final Set<String> cloudBeesUpdateCenterUrls = new HashSet<String>(Arrays.asList(
             CLOUDBEES_UPDATE_CENTER_URL,
-            "http://jenkins-updates.apps.cloudbees.com/update-center/cloudbees-proprietary/update-center.json"
+            "http://jenkins-updates.cloudbees.com/update-center/cloudbees-proprietary/update-center.json"
     ));
 
     /**


### PR DESCRIPTION
http://jenkins-updates.app.cloudbees.com is an invalid hostname for the cloudbees certificate. It will throw an `PKIXCertPathValidator` error when trying to use the `cloudbees-proprietary` update center.

@reviewbybees